### PR TITLE
Don't require setting asset_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@ gem "croppable"
 bin/rails croppable:install
 ```
 
-The asset_host config needs to be set on every environment
-```ruby
-config.asset_host = "http://localhost:3000"
-```
-
 ## Manual setup
 Install cropperjs JavaScript dependency
 ```

--- a/app/controllers/concerns/clean_croppable_params.rb
+++ b/app/controllers/concerns/clean_croppable_params.rb
@@ -17,7 +17,12 @@ module CleanCroppableParams
       params[:croppables].each do |(key, croppable)|
         params[croppable[:base]] ||= {}
         delete = croppable[:delete] == "1"
-        params[croppable[:base]][key] = Croppable::Param.new(croppable[:image], croppable[:data], delete: delete)
+        params[croppable[:base]][key] =
+          Croppable::Param.new(
+            croppable[:image], croppable[:data],
+            delete: delete,
+            host: request.protocol + request.host_with_port
+          )
       end
     end
   end

--- a/app/jobs/croppable/crop_image_job.rb
+++ b/app/jobs/croppable/crop_image_job.rb
@@ -4,8 +4,8 @@ module Croppable
   class CropImageJob < ApplicationJob
     queue_as :default
 
-    def perform(model, croppable_name)
-      Croppable::Crop.new(model, croppable_name).perform()
+    def perform(model, croppable_name, host:)
+      Croppable::Crop.new(model, croppable_name, host: host).perform()
     end
   end
 end

--- a/lib/croppable/crop.rb
+++ b/lib/croppable/crop.rb
@@ -4,13 +4,14 @@ require 'vips'
 module Croppable
 
   class Crop
-    def initialize(model, attr_name)
+    def initialize(model, attr_name, host:)
       @model     = model
       @attr_name = attr_name
       @data      = model.send("#{attr_name}_croppable_data")
       @setup     = model.send("#{attr_name}_croppable_setup")
       original   = model.send("#{attr_name}_original")
-      @url       = Rails.application.routes.url_helpers.rails_blob_url(original, host: Rails.application.config.asset_host)
+      asset_host = Rails.application.config.asset_host || host
+      @url       = Rails.application.routes.url_helpers.rails_blob_url(original, host: host)
     end
 
     def perform()

--- a/lib/croppable/param.rb
+++ b/lib/croppable/param.rb
@@ -1,10 +1,11 @@
 module Croppable
   class Param
-    attr_accessor :image, :data, :delete
+    attr_accessor :image, :data, :host, :delete
 
-    def initialize(image, data, delete: false)
+    def initialize(image, data, host:, delete: false)
       @image = image
       @delete = delete
+      @host = host
       @data  = {
         x:                data[:x],
         y:                data[:y],


### PR DESCRIPTION
Previously, croppable used asset_host in the image processing job to know where to find the uploaded image blob. This requires a team to all run the application on the same port in development, and might complicate CDN deployments if assets aren't yet available on the CDN.

This passes the full root URL all the way down from the controller to the job, which is a lot of handing off but seems workable.