### PR TITLE
Require Rails 7, but not bleeding edge

### DIFF
--- a/croppable.gemspec
+++ b/croppable.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib,javascripts}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 7.0.4.2"
+  spec.add_dependency "rails", ">= 7"
   spec.add_dependency "image_processing", "~> 1.2"
 end


### PR DESCRIPTION
Previously the gemspec required Rails >= 7.0.4.2.

I don't know what the minimum Rails version is for this, it'll probably work at least on Rails 6 I imagine, but anything 7 and above is a safe bet.