### PR TITLE
Set tests as default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,11 @@ load "rails/tasks/engine.rake"
 load "rails/tasks/statistics.rake"
 
 require "bundler/gem_tasks"
+
+require 'rake/testtask'
+Rake::TestTask.new do |t|
+  t.pattern = "test/**/*_test.rb"
+  t.libs << 'test'
+end
+
+task default: [:test]

--- a/test/dummy/db/migrate/20230328223705_create_croppable_data.croppable.rb
+++ b/test/dummy/db/migrate/20230328223705_create_croppable_data.croppable.rb
@@ -1,0 +1,15 @@
+# This migration comes from croppable (originally 20230303170333)
+class CreateCroppableData < ActiveRecord::Migration[7.0]
+  def change
+    create_table :croppable_data do |t|
+      t.references :croppable, polymorphic: true
+      t.string     :name
+      t.float      :scale
+      t.integer    :x
+      t.integer    :y
+      t.string     :background_color
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_09_013631) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_28_223705) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
-ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 require "rails/test_help"
 
 # Load fixtures from the engine


### PR DESCRIPTION
Previously, it wasn't obvious how to get the tests to run, and attempting via rake produced missing table errors. This fixes both by adding tests as a task (the default rake task), and moving the croppable_data migration into the dummy app.