### PR TITLE
Webpack[er] support

### DIFF
--- a/app/assets/javascripts/croppable.esm.js
+++ b/app/assets/javascripts/croppable.esm.js
@@ -1,0 +1,164 @@
+import Cropper from 'cropperjs';
+
+function croppable() {
+  const dropAreas  = document.getElementsByClassName('croppable-droparea');
+
+  Array.from(dropAreas).forEach((dropArea) => {
+    const wrapper = dropArea.closest(".croppable-wrapper");
+    const input   = wrapper.querySelector(".croppable-input");
+
+    input.addEventListener('change', (event) => {
+      const file  = input.files[0];
+
+      const image = document.createElement('img');
+      image.src = URL.createObjectURL(file);
+
+      updateImageDisplay(image, wrapper, true, input);
+    });
+
+    dropArea.onclick = () => input.click();
+
+    dropArea.addEventListener("dragover", (event)=>{
+      event.preventDefault();
+      dropArea.classList.add("active");
+    });
+
+    dropArea.addEventListener("dragleave", ()=>{
+      dropArea.classList.remove("active");
+    });
+
+    dropArea.addEventListener("drop", (event)=>{
+      event.preventDefault();
+
+      const file  = event.dataTransfer.files[0];
+
+      if (file.type.match(/image.*/)) {
+        input.files = event.dataTransfer.files;
+
+        const image = document.createElement('img');
+        image.src   = URL.createObjectURL(file);
+
+        updateImageDisplay(image, wrapper, true, input);
+      }
+
+      dropArea.classList.remove("active");
+    });
+  });
+
+  const images = document.getElementsByClassName('croppable-image');
+
+  Array.from(images).forEach((image) => {
+    const wrapper = image.closest(".croppable-wrapper");
+
+    updateImageDisplay(image, wrapper, false, false);
+  });
+}
+
+function updateImageDisplay(image, wrapper, isNewImage, input) {
+  const controls    = wrapper.querySelector(".croppable-controls");
+  const container   = wrapper.querySelector(".croppable-container");
+  const centerBtn   = wrapper.querySelector(".croppable-center");
+  const fitBtn      = wrapper.querySelector(".croppable-fit");
+  const deleteBtn   = wrapper.querySelector(".croppable-delete");
+  const bgColorBtn  = wrapper.querySelector(".croppable-bgcolor");
+  const xInput      = wrapper.querySelector(".croppable-x");
+  const yInput      = wrapper.querySelector(".croppable-y");
+  const scaleInput  = wrapper.querySelector(".croppable-scale");
+  const deleteInput = wrapper.querySelector(".croppable-input-delete");
+  const dropArea    = wrapper.querySelector(".croppable-droparea");
+  const width       = wrapper.dataset.width;
+  const height      = wrapper.dataset.height;
+
+  dropArea.classList.add("inactive");
+  container.classList.add("active");
+
+  deleteInput.checked    = false;
+  controls.style.display = "flex";
+
+  cleanContainer();
+
+  const cropper = new Cropper(image, {container, template: template(width, height)});
+
+  const cropperImage  = cropper.getCropperImage();
+  const cropperCanvas = cropper.getCropperCanvas();
+
+  cropperCanvas.style.backgroundColor = bgColorBtn.value;
+
+  var saveTransform = false;
+
+  cropperImage.$ready(() => {
+    if (xInput.value != "" && !isNewImage) {
+      var waitForTranform = 10; // needed due turbolinks 🤦
+
+      setTimeout(() => {
+        cropperImage.$setTransform(+scaleInput.value, 0, 0, +scaleInput.value, +xInput.value, +yInput.value);
+
+        saveTransform = true;
+      }, waitForTranform);
+    } else {
+      const matrix     = cropperImage.$getTransform();
+
+      xInput.value     = matrix[4];
+      yInput.value     = matrix[5];
+      scaleInput.value = matrix[0];
+
+      saveTransform = true;
+    }
+  });
+
+  cropperImage.addEventListener('transform', (event) => {
+    if(saveTransform) {
+      const matrix = event.detail.matrix;
+      xInput.value     = matrix[4];
+      yInput.value     = matrix[5];
+      scaleInput.value = matrix[0];
+    }
+  });
+
+  bgColorBtn.addEventListener("change", (event) => {
+    event.preventDefault();
+    cropperCanvas.style.backgroundColor = event.target.value;
+  });
+
+  centerBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+    cropperImage.$center('cover');
+  });
+
+  fitBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+    cropperImage.$center('contain');
+  });
+
+  deleteBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+
+    deleteInput.checked = true;
+
+    if (input) { input.value = ""; }
+
+    cleanContainer();
+
+    dropArea.classList.remove("inactive");
+    container.classList.remove("active");
+
+    controls.style.display = "none";
+  });
+
+  function cleanContainer() {
+    while(container.firstChild) {
+      container.removeChild(container.lastChild);
+    }
+  }
+}
+
+function template(width, height) {
+  return `
+<cropper-canvas style="height: ${height}px; width: ${width}px;">
+  <cropper-image slottable></cropper-image>
+  <cropper-handle action="move" plain></cropper-handle>
+</cropper-canvas>
+  `
+}
+
+export { croppable as default };

--- a/app/assets/javascripts/croppable.js
+++ b/app/assets/javascripts/croppable.js
@@ -1,167 +1,174 @@
-import Cropper from 'cropperjs';
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('cropperjs')) :
+  typeof define === 'function' && define.amd ? define(['cropperjs'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.Croppable = factory(global.Cropper));
+})(this, (function (Cropper) { 'use strict';
 
-document.addEventListener('turbo:load', start);
-document.addEventListener('DOMContentLoaded', start);
+  function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
-function start() {
-  document.removeEventListener('DOMContentLoaded', start)
+  var Cropper__default = /*#__PURE__*/_interopDefaultLegacy(Cropper);
 
-  const dropAreas  = document.getElementsByClassName('croppable-droparea');
+  function croppable() {
+    const dropAreas  = document.getElementsByClassName('croppable-droparea');
 
-  Array.from(dropAreas).forEach((dropArea) => {
-    const wrapper = dropArea.closest(".croppable-wrapper");
-    const input   = wrapper.querySelector(".croppable-input");
+    Array.from(dropAreas).forEach((dropArea) => {
+      const wrapper = dropArea.closest(".croppable-wrapper");
+      const input   = wrapper.querySelector(".croppable-input");
 
-    input.addEventListener('change', (event) => {
-      const file  = input.files[0];
-
-      const image = document.createElement('img');
-      image.src = URL.createObjectURL(file);
-
-      updateImageDisplay(image, wrapper, true, input)
-    });
-
-    dropArea.onclick = () => input.click()
-
-    dropArea.addEventListener("dragover", (event)=>{
-      event.preventDefault();
-      dropArea.classList.add("active");
-    });
-
-    dropArea.addEventListener("dragleave", ()=>{
-      dropArea.classList.remove("active");
-    });
-
-    dropArea.addEventListener("drop", (event)=>{
-      event.preventDefault();
-
-      const file  = event.dataTransfer.files[0];
-
-      if (file.type.match(/image.*/)) {
-        input.files = event.dataTransfer.files;
+      input.addEventListener('change', (event) => {
+        const file  = input.files[0];
 
         const image = document.createElement('img');
-        image.src   = URL.createObjectURL(file);
+        image.src = URL.createObjectURL(file);
 
-        updateImageDisplay(image, wrapper, true, input)
-      }
+        updateImageDisplay(image, wrapper, true, input);
+      });
 
-      dropArea.classList.remove("active");
+      dropArea.onclick = () => input.click();
+
+      dropArea.addEventListener("dragover", (event)=>{
+        event.preventDefault();
+        dropArea.classList.add("active");
+      });
+
+      dropArea.addEventListener("dragleave", ()=>{
+        dropArea.classList.remove("active");
+      });
+
+      dropArea.addEventListener("drop", (event)=>{
+        event.preventDefault();
+
+        const file  = event.dataTransfer.files[0];
+
+        if (file.type.match(/image.*/)) {
+          input.files = event.dataTransfer.files;
+
+          const image = document.createElement('img');
+          image.src   = URL.createObjectURL(file);
+
+          updateImageDisplay(image, wrapper, true, input);
+        }
+
+        dropArea.classList.remove("active");
+      });
     });
-  });
 
-  const images = document.getElementsByClassName('croppable-image');
+    const images = document.getElementsByClassName('croppable-image');
 
-  Array.from(images).forEach((image) => {
-    const wrapper = image.closest(".croppable-wrapper");
+    Array.from(images).forEach((image) => {
+      const wrapper = image.closest(".croppable-wrapper");
 
-    updateImageDisplay(image, wrapper, false, false)
-  });
-}
+      updateImageDisplay(image, wrapper, false, false);
+    });
+  }
 
-function updateImageDisplay(image, wrapper, isNewImage, input) {
-  const controls    = wrapper.querySelector(".croppable-controls");
-  const container   = wrapper.querySelector(".croppable-container");
-  const centerBtn   = wrapper.querySelector(".croppable-center");
-  const fitBtn      = wrapper.querySelector(".croppable-fit");
-  const deleteBtn   = wrapper.querySelector(".croppable-delete");
-  const bgColorBtn  = wrapper.querySelector(".croppable-bgcolor");
-  const xInput      = wrapper.querySelector(".croppable-x");
-  const yInput      = wrapper.querySelector(".croppable-y");
-  const scaleInput  = wrapper.querySelector(".croppable-scale");
-  const deleteInput = wrapper.querySelector(".croppable-input-delete");
-  const dropArea    = wrapper.querySelector(".croppable-droparea");
-  const width       = wrapper.dataset.width;
-  const height      = wrapper.dataset.height;
+  function updateImageDisplay(image, wrapper, isNewImage, input) {
+    const controls    = wrapper.querySelector(".croppable-controls");
+    const container   = wrapper.querySelector(".croppable-container");
+    const centerBtn   = wrapper.querySelector(".croppable-center");
+    const fitBtn      = wrapper.querySelector(".croppable-fit");
+    const deleteBtn   = wrapper.querySelector(".croppable-delete");
+    const bgColorBtn  = wrapper.querySelector(".croppable-bgcolor");
+    const xInput      = wrapper.querySelector(".croppable-x");
+    const yInput      = wrapper.querySelector(".croppable-y");
+    const scaleInput  = wrapper.querySelector(".croppable-scale");
+    const deleteInput = wrapper.querySelector(".croppable-input-delete");
+    const dropArea    = wrapper.querySelector(".croppable-droparea");
+    const width       = wrapper.dataset.width;
+    const height      = wrapper.dataset.height;
 
-  dropArea.classList.add("inactive");
-  container.classList.add("active");
+    dropArea.classList.add("inactive");
+    container.classList.add("active");
 
-  deleteInput.checked    = false;
-  controls.style.display = "flex";
+    deleteInput.checked    = false;
+    controls.style.display = "flex";
 
-  cleanContainer()
+    cleanContainer();
 
-  const cropper = new Cropper(image, {container, template: template(width, height)});
+    const cropper = new Cropper__default["default"](image, {container, template: template(width, height)});
 
-  const cropperImage  = cropper.getCropperImage();
-  const cropperCanvas = cropper.getCropperCanvas();
+    const cropperImage  = cropper.getCropperImage();
+    const cropperCanvas = cropper.getCropperCanvas();
 
-  cropperCanvas.style.backgroundColor = bgColorBtn.value;
+    cropperCanvas.style.backgroundColor = bgColorBtn.value;
 
-  var saveTransform = false;
+    var saveTransform = false;
 
-  cropperImage.$ready(() => {
-    if (xInput.value != "" && !isNewImage) {
-      var waitForTranform = 10; // needed due turbolinks 🤦
+    cropperImage.$ready(() => {
+      if (xInput.value != "" && !isNewImage) {
+        var waitForTranform = 10; // needed due turbolinks 🤦
 
-      setTimeout(() => {
-        cropperImage.$setTransform(+scaleInput.value, 0, 0, +scaleInput.value, +xInput.value, +yInput.value);
+        setTimeout(() => {
+          cropperImage.$setTransform(+scaleInput.value, 0, 0, +scaleInput.value, +xInput.value, +yInput.value);
+
+          saveTransform = true;
+        }, waitForTranform);
+      } else {
+        const matrix     = cropperImage.$getTransform();
+
+        xInput.value     = matrix[4];
+        yInput.value     = matrix[5];
+        scaleInput.value = matrix[0];
 
         saveTransform = true;
-      }, waitForTranform)
-    } else {
-      const matrix     = cropperImage.$getTransform();
+      }
+    });
 
-      xInput.value     = matrix[4];
-      yInput.value     = matrix[5];
-      scaleInput.value = matrix[0];
+    cropperImage.addEventListener('transform', (event) => {
+      if(saveTransform) {
+        const matrix = event.detail.matrix;
+        xInput.value     = matrix[4];
+        yInput.value     = matrix[5];
+        scaleInput.value = matrix[0];
+      }
+    });
 
-      saveTransform = true;
-    }
-  })
+    bgColorBtn.addEventListener("change", (event) => {
+      event.preventDefault();
+      cropperCanvas.style.backgroundColor = event.target.value;
+    });
 
-  cropperImage.addEventListener('transform', (event) => {
-    if(saveTransform) {
-      const matrix = event.detail.matrix;
-      xInput.value     = matrix[4];
-      yInput.value     = matrix[5];
-      scaleInput.value = matrix[0];
-    }
-  });
+    centerBtn.addEventListener("click", (event) => {
+      event.preventDefault();
+      cropperImage.$center('cover');
+    });
 
-  bgColorBtn.addEventListener("change", (event) => {
-    event.preventDefault();
-    cropperCanvas.style.backgroundColor = event.target.value;
-  })
+    fitBtn.addEventListener("click", (event) => {
+      event.preventDefault();
+      cropperImage.$center('contain');
+    });
 
-  centerBtn.addEventListener("click", (event) => {
-    event.preventDefault();
-    cropperImage.$center('cover')
-  })
+    deleteBtn.addEventListener("click", (event) => {
+      event.preventDefault();
 
-  fitBtn.addEventListener("click", (event) => {
-    event.preventDefault();
-    cropperImage.$center('contain')
-  })
+      deleteInput.checked = true;
 
-  deleteBtn.addEventListener("click", (event) => {
-    event.preventDefault();
+      if (input) { input.value = ""; }
 
-    deleteInput.checked = true;
+      cleanContainer();
 
-    if (input) { input.value = ""; }
+      dropArea.classList.remove("inactive");
+      container.classList.remove("active");
 
-    cleanContainer()
+      controls.style.display = "none";
+    });
 
-    dropArea.classList.remove("inactive");
-    container.classList.remove("active");
-
-    controls.style.display = "none";
-  })
-
-  function cleanContainer() {
-    while(container.firstChild) {
-      container.removeChild(container.lastChild);
+    function cleanContainer() {
+      while(container.firstChild) {
+        container.removeChild(container.lastChild);
+      }
     }
   }
-}
 
-function template(width, height) {
-  return `
+  function template(width, height) {
+    return `
 <cropper-canvas style="height: ${height}px; width: ${width}px;">
   <cropper-image slottable></cropper-image>
   <cropper-handle action="move" plain></cropper-handle>
 </cropper-canvas>
   `
-}
+  }
+
+  return croppable;
+
+}));

--- a/app/javascript/croppable/index.js
+++ b/app/javascript/croppable/index.js
@@ -1,0 +1,162 @@
+import Cropper from 'cropperjs';
+
+export default function croppable() {
+  const dropAreas  = document.getElementsByClassName('croppable-droparea');
+
+  Array.from(dropAreas).forEach((dropArea) => {
+    const wrapper = dropArea.closest(".croppable-wrapper");
+    const input   = wrapper.querySelector(".croppable-input");
+
+    input.addEventListener('change', (event) => {
+      const file  = input.files[0];
+
+      const image = document.createElement('img');
+      image.src = URL.createObjectURL(file);
+
+      updateImageDisplay(image, wrapper, true, input)
+    });
+
+    dropArea.onclick = () => input.click()
+
+    dropArea.addEventListener("dragover", (event)=>{
+      event.preventDefault();
+      dropArea.classList.add("active");
+    });
+
+    dropArea.addEventListener("dragleave", ()=>{
+      dropArea.classList.remove("active");
+    });
+
+    dropArea.addEventListener("drop", (event)=>{
+      event.preventDefault();
+
+      const file  = event.dataTransfer.files[0];
+
+      if (file.type.match(/image.*/)) {
+        input.files = event.dataTransfer.files;
+
+        const image = document.createElement('img');
+        image.src   = URL.createObjectURL(file);
+
+        updateImageDisplay(image, wrapper, true, input)
+      }
+
+      dropArea.classList.remove("active");
+    });
+  });
+
+  const images = document.getElementsByClassName('croppable-image');
+
+  Array.from(images).forEach((image) => {
+    const wrapper = image.closest(".croppable-wrapper");
+
+    updateImageDisplay(image, wrapper, false, false)
+  });
+}
+
+function updateImageDisplay(image, wrapper, isNewImage, input) {
+  const controls    = wrapper.querySelector(".croppable-controls");
+  const container   = wrapper.querySelector(".croppable-container");
+  const centerBtn   = wrapper.querySelector(".croppable-center");
+  const fitBtn      = wrapper.querySelector(".croppable-fit");
+  const deleteBtn   = wrapper.querySelector(".croppable-delete");
+  const bgColorBtn  = wrapper.querySelector(".croppable-bgcolor");
+  const xInput      = wrapper.querySelector(".croppable-x");
+  const yInput      = wrapper.querySelector(".croppable-y");
+  const scaleInput  = wrapper.querySelector(".croppable-scale");
+  const deleteInput = wrapper.querySelector(".croppable-input-delete");
+  const dropArea    = wrapper.querySelector(".croppable-droparea");
+  const width       = wrapper.dataset.width;
+  const height      = wrapper.dataset.height;
+
+  dropArea.classList.add("inactive");
+  container.classList.add("active");
+
+  deleteInput.checked    = false;
+  controls.style.display = "flex";
+
+  cleanContainer()
+
+  const cropper = new Cropper(image, {container, template: template(width, height)});
+
+  const cropperImage  = cropper.getCropperImage();
+  const cropperCanvas = cropper.getCropperCanvas();
+
+  cropperCanvas.style.backgroundColor = bgColorBtn.value;
+
+  var saveTransform = false;
+
+  cropperImage.$ready(() => {
+    if (xInput.value != "" && !isNewImage) {
+      var waitForTranform = 10; // needed due turbolinks 🤦
+
+      setTimeout(() => {
+        cropperImage.$setTransform(+scaleInput.value, 0, 0, +scaleInput.value, +xInput.value, +yInput.value);
+
+        saveTransform = true;
+      }, waitForTranform)
+    } else {
+      const matrix     = cropperImage.$getTransform();
+
+      xInput.value     = matrix[4];
+      yInput.value     = matrix[5];
+      scaleInput.value = matrix[0];
+
+      saveTransform = true;
+    }
+  })
+
+  cropperImage.addEventListener('transform', (event) => {
+    if(saveTransform) {
+      const matrix = event.detail.matrix;
+      xInput.value     = matrix[4];
+      yInput.value     = matrix[5];
+      scaleInput.value = matrix[0];
+    }
+  });
+
+  bgColorBtn.addEventListener("change", (event) => {
+    event.preventDefault();
+    cropperCanvas.style.backgroundColor = event.target.value;
+  })
+
+  centerBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+    cropperImage.$center('cover')
+  })
+
+  fitBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+    cropperImage.$center('contain')
+  })
+
+  deleteBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+
+    deleteInput.checked = true;
+
+    if (input) { input.value = ""; }
+
+    cleanContainer()
+
+    dropArea.classList.remove("inactive");
+    container.classList.remove("active");
+
+    controls.style.display = "none";
+  })
+
+  function cleanContainer() {
+    while(container.firstChild) {
+      container.removeChild(container.lastChild);
+    }
+  }
+}
+
+function template(width, height) {
+  return `
+<cropper-canvas style="height: ${height}px; width: ${width}px;">
+  <cropper-image slottable></cropper-image>
+  <cropper-handle action="move" plain></cropper-handle>
+</cropper-canvas>
+  `
+}

--- a/croppable.gemspec
+++ b/croppable.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/stevenbarragan/croppable"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir["{app,config,db,lib,javascripts}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
   spec.add_dependency "rails", "~> 7.0"

--- a/dist/croppable.css
+++ b/dist/croppable.css
@@ -1,0 +1,71 @@
+.croppable-preview {
+  display: flex;
+}
+
+.croppable-wrapper {
+  margin-bottom: 1em;
+}
+
+.croppable-controls {
+  display: none;
+  flex-direction: column;
+  padding: 0 0.7em;
+}
+
+.croppable-input-delete, .croppable-input {
+  display: none;
+}
+
+.croppable-controls button {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  border-radius: 4px;
+  border: 1px solid #3a4855;
+  cursor: pointer;
+  margin-bottom: 3px;
+  padding: 0;
+  height: 30px;
+  width: 35px;
+}
+
+.croppable-controls .croppable-bgcolor {
+  cursor: pointer;
+  margin-bottom: 3px;
+  padding: 4px;
+  height: 30px;
+  width: 35px;
+}
+
+.croppable-delete img {
+  height: 28px;
+}
+
+.croppable-center {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA4klEQVR4nO2XUQ6CMAyGewkWd/+b6HYBefA49XWWFlkk+m/+X7KQQCF8dO2GCCGEEEJe0EHHhulERkEpAoYyI7NnpAbd5NYRWxBENBhXJ7b0tNFfijxEJB+4ZxGRO6rI2hzTTnwysXAiS/OVo8zYmAuiiLyR8SQESaSYwrZTJwXn2vu9DgexINoXP1o/kCu77UztdBpeJJ/4fOXUCqimWHuLvaJtUfZarHcto7VfDRZEr7A9GTiRdZYtina0WOhNo37wPwIhUk74H4HdonwDpQgYyoyMlhEdbGyYRoQQQgj5W57BIckAMCn5cwAAAABJRU5ErkJggg==');
+}
+
+.croppable-fit {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAAsTAAALEwEAmpwYAAABJklEQVR4nO2XbQ6DMAiGuYRGD9ZL7hh+XGD+2HHYH026plRBW7HjScgSi8LrgFYAwzAMwzB+wIil1kraRmqtXiHctZygJCcTkhG8uko0lpaIRwlxq3EfOBPTZGT4ToK4jspXWo/UyBwivuOBEXvb1PKT+QBAD/s0APDWKmTxftuEiDbwVSek8d4y9c+EPp1GIbAjJiYCNAkZg8YOS6clrlH3n87ptRrrJoIw8aP9w4mbyvfSjSmcTH455YxbREhfIC5UU1oobPY5OI5wm30WHlGw5Pj1e4Iazeo3xC7iGxOjTshSyxEFGSNW9aERT3yPXCrECT+sJiKxgeE7CuK6RL7ldti74uKThKCwVnOCJZs9J2hCID4S8WbbODS2qxFiGIZhGH/LF6hxCMsktMvWAAAAAElFTkSuQmCC');
+}
+
+.croppable-delete {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA4UlEQVR4nO2aSw7CIBRFz6iLUren1W3JwLiPttvASDAhJi9tlRbS3pO8CaGfm8eZACC2SwPcgAHwI9UDbXymOq4TAnzXhQrp488dJsw9Jp2pDh9rqfmrUXUQ98O6X6rcVoLcc3Sm1Hr2ub+rIH/i1RGDXS2tJ/DIMF48iDVn7niKglioI2hpBeSIhRxBjgTkiIUcQY4E5IiFHEGOBOSIhRxBjgTkiIUcQY6Uc8QZZxhzx1O0iW2xq03sJfAKMnIZ4H3Qvxan+M0u50vbgqe555xBmhjm05k1qoshqrx4IxjhBYDU2PkqqpaWAAAAAElFTkSuQmCC');
+  background-size: 23px !important;
+}
+
+.croppable-droparea {
+  background: #5256ad;
+  border-radius: 5px;
+  border: 2px dashed #fff;
+  box-sizing: content-box;
+  cursor: pointer;
+}
+
+.croppable-droparea.active, .croppable-container.active {
+  border: 2px solid #4D37AD;
+}
+
+.croppable-droparea.inactive {
+  display: none;
+}

--- a/lib/croppable/engine.rb
+++ b/lib/croppable/engine.rb
@@ -18,10 +18,9 @@ module Croppable
     initializer "croppable.assets.precompile" do
       config.after_initialize do |app|
         if app.config.respond_to?(:assets)
-          app.config.assets.precompile += %w( croppable.js croppable.css  )
+          app.config.assets.precompile += %w( croppable.js croppable.esm.js croppable.css  )
         end
       end
     end
-
   end
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,821 @@
+{
+  "name": "croppable",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "croppable",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "cropperjs": "^2.0.0-beta.2"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^19.0.1",
+        "@rollup/plugin-node-resolve": "^11.0.1",
+        "rollup": "^2.35.1",
+        "rollup-plugin-terser": "^7.0.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cropper/element": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element/-/element-2.0.0-beta.2.tgz",
+      "integrity": "sha512-i3wfelk5d4MLNgAcQpRa/jOaxWAcDLRAUkiHmU6CMl7xvOAD/4TFQGB3qSpzgx3NK4hUDLn80/gp7gM2nvrBWg==",
+      "dependencies": {
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-canvas": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-canvas/-/element-canvas-2.0.0-beta.2.tgz",
+      "integrity": "sha512-LZcnMwv7M3ZxUKX9YrYGxqbf8YsYfeIUFREaB/IkKsm7E7ASaDrrjdc996QYMjdjUNcWdJjxhsoucPNEvl/DXA==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-crosshair": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-crosshair/-/element-crosshair-2.0.0-beta.2.tgz",
+      "integrity": "sha512-kBxZ2zZ7uR7XlQcnUbudq7562XwtTOqbGNYg5VWem/ukcAAKwYmPlapNlv7n228DSUGEz5FxKW8GSwLucJlQ0Q==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-grid": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-grid/-/element-grid-2.0.0-beta.2.tgz",
+      "integrity": "sha512-rWMOjlj+eq9L2oxAthNYdGxbV3sYyV+tra6VAuooZl+RbdQZ9XCnG0Pitb/RfgPZb860ia0q8biE5zEq4Uc8fA==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-handle": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-handle/-/element-handle-2.0.0-beta.2.tgz",
+      "integrity": "sha512-IAFyqldnB57ZGzvf3VuE7Y9UAaq9IMmun15v17cAWX1q4ZCVqdFrugAWpRF+V5WgHBL2doxHUOQlfy7LznzRmg==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-image": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-image/-/element-image-2.0.0-beta.2.tgz",
+      "integrity": "sha512-FgYb+GfcxdewH6VKgw6Ltws8fw3TSP8d0HMH/WZubBC2w/NNAvp92EonwgjDoTLEFFJKbj5P2aKTFY0aO70R0Q==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/element-canvas": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-selection": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-selection/-/element-selection-2.0.0-beta.2.tgz",
+      "integrity": "sha512-O/fxpJe/WB5H+mELSVfp4tOAAa7yMVa+wn35DCRxaDPb/1Um55E7OT1G3puAL9Elm7NFA/CCMYuHohl9emE25A==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/element-canvas": "^2.0.0-beta.2",
+        "@cropper/element-image": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-shade": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-shade/-/element-shade-2.0.0-beta.2.tgz",
+      "integrity": "sha512-aY5RP2ygteq51ZDU3+rAj+f+0hSgEf+vRAdJ1YO2bJ1n25TpOaz2klO5COdHxn3unLVjYK97khIZGs7ClbV0rQ==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/element-canvas": "^2.0.0-beta.2",
+        "@cropper/element-selection": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/element-viewer": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/element-viewer/-/element-viewer-2.0.0-beta.2.tgz",
+      "integrity": "sha512-/2BhLFr2Ti5LnRvcIlLlR3NDSF3x9w9BvYukFbnCxoTLIbGvwM02YQV2Qx+al8C0mBoW0ab6uF5ykl6W8i9WkQ==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/element-canvas": "^2.0.0-beta.2",
+        "@cropper/element-image": "^2.0.0-beta.2",
+        "@cropper/element-selection": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/elements": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/elements/-/elements-2.0.0-beta.2.tgz",
+      "integrity": "sha512-l08CmeOvLJ8XLJ95OQ+kSHSbf7+pHcsu3pvQYjustbrUj0H1vzBiWT8VygPjkCUMoVIfsBpYmBNpWVGJvjoy2Q==",
+      "dependencies": {
+        "@cropper/element": "^2.0.0-beta.2",
+        "@cropper/element-canvas": "^2.0.0-beta.2",
+        "@cropper/element-crosshair": "^2.0.0-beta.2",
+        "@cropper/element-grid": "^2.0.0-beta.2",
+        "@cropper/element-handle": "^2.0.0-beta.2",
+        "@cropper/element-image": "^2.0.0-beta.2",
+        "@cropper/element-selection": "^2.0.0-beta.2",
+        "@cropper/element-shade": "^2.0.0-beta.2",
+        "@cropper/element-viewer": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/@cropper/utils": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@cropper/utils/-/utils-2.0.0-beta.2.tgz",
+      "integrity": "sha512-RJu5IWzH6vcygwLsx9KEqzwjnEqApPkSFViMzxCRbe0IuAXt2ZlSUmYKgLFZY+YJIdaZ+/P7PwiUcZ7GYH3Msw=="
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.2.tgz",
+      "integrity": "sha512-gBjarfqlC7qs0AutpRW/hrFNm+cd2/QKxhwyFa+srbg1oX7rDsEU3l+W7LAUhsAp9mPJMAkXDhLbQaVwEaE8bA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.38.3"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
+      "integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
+      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
+      "dev": true
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/cropperjs": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-2.0.0-beta.2.tgz",
+      "integrity": "sha512-jDRSODDGKmi9vp3p/+WXkxMqV/AE+GpSld1U3cHZDRdLy9UykRzurSe8k1dR0TExn45ygCMrv31qkg+K3EeXXw==",
+      "dependencies": {
+        "@cropper/elements": "^2.0.0-beta.2",
+        "@cropper/utils": "^2.0.0-beta.2"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
+      "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "croppable",
+  "version": "0.2.0",
+  "description": "Easily crop images in Ruby on Rails with Cropper.js integration",
+  "main": "app/assets/javascripts/croppable.js",
+  "module": "app/assets/javascripts/croppable.esm.js",
+  "files": [
+    "app/assets/javascripts/croppable.*",
+    "dist/croppable.css"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "stevenbarragan/croppable"
+  },
+  "keywords": [
+    "cropperjs",
+    "rails"
+  ],
+  "dependencies": {
+    "cropperjs": "^2.0.0-beta.2"
+  },
+  "author": "Steven Barragán",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/stevenbarragan/croppable/issues"
+  },
+  "homepage": "https://github.com/stevenbarragan/croppable#readme",
+  "scripts": {
+    "build": "rollup --config rollup.config.mjs && cp app/assets/stylesheets/croppable.css dist"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^11.0.1",
+    "@rollup/plugin-commonjs": "^19.0.1",
+    "rollup": "^2.35.1"
+   }
+}

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,20 @@
+export default [
+  {
+    input: "app/javascript/croppable/index.js",
+    output: [
+      {
+        file: "app/assets/javascripts/croppable.js",
+        format: "umd",
+        name: "Croppable",
+        globals: {
+          'cropperjs': 'Cropper'
+        }
+      },
+      {
+        file: "app/assets/javascripts/croppable.esm.js",
+        format: "es",
+      }
+    ],
+    external: ['cropperjs']
+  }
+]

--- a/test/dummy/app/javascript/application.js
+++ b/test/dummy/app/javascript/application.js
@@ -1,1 +1,3 @@
-import "croppable"
+import croppable from "croppable"
+
+croppable()

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -15,4 +15,4 @@ pin "@cropper/element-viewer", to: "https://ga.jspm.io/npm:@cropper/element-view
 pin "@cropper/elements", to: "https://ga.jspm.io/npm:@cropper/elements@2.0.0-beta.2/dist/elements.esm.raw.js"
 pin "@cropper/utils", to: "https://ga.jspm.io/npm:@cropper/utils@2.0.0-beta.2/dist/utils.esm.raw.js"
 
-pin "croppable"
+pin "croppable", to: 'croppable.esm'


### PR DESCRIPTION
Previously, ESM modules / sprockets was the only way to include the files in a Rails project.

The official way to include gem-based javascript in a webpacker-based Rails project is to create an npm module, see ActionCable as an example: https://github.com/rails/rails/tree/main/actioncable

This adds webpacker support by copying the ActionCable approach, including using rollup to transpile a plain JS file into ESM and UMD versions.

Related, this also makes the croppable javascript export a function to invoke the croppable functionality instead of hardcoding callbacks on DOMContentLoaded and turbo:load events, which lets the project be more flexible in how it's instantiated (ex. via turbolinks instead of turbo).