### PR TITLE
Fix small image cropping

### DIFF
--- a/app/assets/stylesheets/croppable.css
+++ b/app/assets/stylesheets/croppable.css
@@ -1,3 +1,10 @@
+/* For some reason cropperjs makes the canvas a min-width of 200px,
+ * but a min-height of 100px. This breaks uploading small square logos.
+ * Let's set the min-width to match the min-height. */
+cropper-canvas {
+  min-width: 100px;
+}
+
 .croppable-preview {
   display: flex;
 }

--- a/dist/croppable.css
+++ b/dist/croppable.css
@@ -1,3 +1,10 @@
+/* For some reason cropperjs makes the canvas a min-width of 200px,
+ * but a min-height of 100px. This breaks uploading small square logos.
+ * Let's set the min-width to match the min-height. */
+cropper-canvas {
+  min-width: 100px;
+}
+
 .croppable-preview {
   display: flex;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "croppable",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Easily crop images in Ruby on Rails with Cropper.js integration",
   "main": "app/assets/javascripts/croppable.js",
   "module": "app/assets/javascripts/croppable.esm.js",


### PR DESCRIPTION
Depends on #9 

For some reason cropperjs makes the canvas a min-width of 200px,
but a min-height of 100px. This breaks uploading small square logos.

This sets the min-width to match the min-height.
